### PR TITLE
Support R2019a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.mltbx
+code/mtcnn/weights/dag*.mat

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Face Detection and Alignment MTCNN
 
-![matlab-deep-learning](https://circleci.com/gh/matlab-deep-learning/mtcnn-face-detection.svg?style=svg)
+![circleci](https://circleci.com/gh/matlab-deep-learning/mtcnn-face-detection.svg?style=svg)
 [![codecov](https://codecov.io/gh/matlab-deep-learning/mtcnn-face-detection/branch/master/graph/badge.svg)](https://codecov.io/gh/matlab-deep-learning/mtcnn-face-detection)
 
 ## [__Download the toolbox here__](https://github.com/matlab-deep-learning/mtcnn-face-detection/releases/latest/download/MTCNN-Face-Detection.mltbx)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: This code supports inference using a pretrained model. Training from scra
 ## Installation
 
 - Face Detection and Alignment MTCNN requires the following products:
-  - MATLAB R2019b or later
+  - MATLAB R2019a or later (_now works in R2019a and later!_)
   - Deep Learning Toolbox
   - Computer Vision Toolbox
   - Image Processing Toolbox
@@ -65,10 +65,6 @@ _Face detection from MTCNN in yellow, detections from the built in vision.Cascad
 
 ## Contribute
 
-Please file any bug reports or feature requests as [GitHub issues](https://github.com/matlab-deep-learning/mtcnn-face-detection/issues). In particular comment on the following two issues if they interest you!
-
-- [Support training MTCNN](https://github.com/matlab-deep-learning/mtcnn-face-detection/issues/1)
-- [Support MATLAB versions earlier than R2019b](https://github.com/matlab-deep-learning/mtcnn-face-detection/issues/2)
-
+Please file any bug reports or feature requests as [GitHub issues](https://github.com/matlab-deep-learning/mtcnn-face-detection/issues). In particular if you'd be interested in training your own MTCNN network comment on the following issue: [Support training MTCNN](https://github.com/matlab-deep-learning/mtcnn-face-detection/issues/1)
 
 _Copyright 2019 The MathWorks, Inc._

--- a/code/mtcnn/+mtcnn/+util/DagNetworkStrategy.m
+++ b/code/mtcnn/+mtcnn/+util/DagNetworkStrategy.m
@@ -1,0 +1,41 @@
+classdef DagNetworkStrategy < handle
+    
+    properties (SetAccess=private)
+        % Trained Dag networks
+        Pnet
+        Rnet
+        Onet
+    end
+    
+    methods
+        function obj = DagNetworkStrategy()
+        end
+        
+        function load(obj)
+            % loadWeights   Load the network weights from file.
+            obj.Pnet = importdata(fullfile(mtcnnRoot(), "weights", "dagPnet.mat"));
+            obj.Rnet = importdata(fullfile(mtcnnRoot(), "weights", "dagRnet.mat"));
+            obj.Onet = importdata(fullfile(mtcnnRoot(), "weights", "dagOnet.mat"));
+        end
+        
+        function pnet = getPNet(obj)
+            pnet = obj.Pnet;
+        end
+        
+        function [probs, correction] = applyRNet(obj, im)
+            output = obj.Rnet.predict(im);
+            
+            probs = output(:,1:2);
+            correction = output(:,3:end);
+        end
+        
+        function [probs, correction, landmarks] = applyONet(obj, im)
+            output = obj.Onet.predict(im);
+            
+            probs = output(:,1:2);
+            correction = output(:,3:6);
+            landmarks = output(:,7:end);
+        end
+        
+    end
+end

--- a/code/mtcnn/+mtcnn/+util/DagNetworkStrategy.m
+++ b/code/mtcnn/+mtcnn/+util/DagNetworkStrategy.m
@@ -13,9 +13,9 @@ classdef DagNetworkStrategy < handle
         
         function load(obj)
             % loadWeights   Load the network weights from file.
-            obj.Pnet = importdata(fullfile(mtcnnRoot(), "weights", "dagPnet.mat"));
-            obj.Rnet = importdata(fullfile(mtcnnRoot(), "weights", "dagRnet.mat"));
-            obj.Onet = importdata(fullfile(mtcnnRoot(), "weights", "dagOnet.mat"));
+            obj.Pnet = importdata(fullfile(mtcnnRoot(), "weights", "dagPNet.mat"));
+            obj.Rnet = importdata(fullfile(mtcnnRoot(), "weights", "dagRNet.mat"));
+            obj.Onet = importdata(fullfile(mtcnnRoot(), "weights", "dagONet.mat"));
         end
         
         function pnet = getPNet(obj)

--- a/code/mtcnn/+mtcnn/+util/DlNetworkStrategy.m
+++ b/code/mtcnn/+mtcnn/+util/DlNetworkStrategy.m
@@ -1,0 +1,53 @@
+classdef DlNetworkStrategy < handle
+    
+    properties (SetAccess=private)
+        UseGPU
+        % Weights for the networks
+        PnetWeights
+        RnetWeights
+        OnetWeights
+    end
+    
+    methods
+        function obj = DlNetworkStrategy(useGpu)
+            obj.UseGPU = useGpu;
+        end
+        
+        function load(obj)
+            % loadWeights   Load the network weights from file.
+            obj.PnetWeights = load(fullfile(mtcnnRoot(), "weights", "pnet.mat"));
+            obj.RnetWeights = load(fullfile(mtcnnRoot(), "weights", "rnet.mat"));
+            obj.OnetWeights = load(fullfile(mtcnnRoot(), "weights", "onet.mat"));
+            
+            if obj.UseGPU
+                obj.PnetWeights = dlupdate(@gpuArray, obj.PnetWeights);
+                obj.RnetWeights = dlupdate(@gpuArray, obj.RnetWeights);
+                obj.OnetWeights = dlupdate(@gpuArray, obj.OnetWeights);
+            end
+        end
+        
+        function pnet = getPNet(obj)
+            pnet = obj.PnetWeights;
+        end
+        
+        function [probs, correction] = applyRNet(obj, im)
+            im = dlarray(im, "SSCB");
+            
+            [probs, correction] = mtcnn.rnet(im, obj.RnetWeights);
+            
+            probs = extractdata(probs)';
+            correction = extractdata(correction)';
+        end
+        
+        function [probs, correction, landmarks] = applyONet(obj, im)
+            im = dlarray(im, "SSCB");
+            
+            [probs, correction, landmarks] = mtcnn.onet(im, obj.OnetWeights);
+            
+            probs = extractdata(probs)';
+            correction = extractdata(correction)';
+            landmarks = extractdata(landmarks)';
+        end
+        
+    end
+end

--- a/code/mtcnn/+mtcnn/+util/NetworkStrategy.m
+++ b/code/mtcnn/+mtcnn/+util/NetworkStrategy.m
@@ -1,0 +1,8 @@
+classdef (Abstract) NetworkStrategy < handle
+    methods
+        load(obj)
+        pnet = getPNet(obj)
+        [probs, correction] = applyRNet(obj, im)
+        [probs, correction, landmarks] = applyONet(obj, im)
+    end
+end

--- a/code/mtcnn/+mtcnn/+util/convertToDagNet.m
+++ b/code/mtcnn/+mtcnn/+util/convertToDagNet.m
@@ -1,0 +1,99 @@
+function net = convertToDagNet(stage)
+    
+    warnId = "deep:functionToLayerGraph:Placeholder";
+    warnState = warning('off', warnId);
+    restoreWarn = onCleanup(@() warning(warnState));
+    
+    switch stage
+        case "p"
+            inputSize = 12;
+            nBlocks = 3;
+            finalConnections = [sprintf("conv_%d", nBlocks), sprintf("prelu_%d", nBlocks)];
+            catConnections = ["sm_1", "conv_5"];
+        case "r"
+            inputSize = 24;
+            nBlocks = 4;
+            finalConnections = [sprintf("prelu_%d", nBlocks-1), "fc_1";
+                                "fc_1", sprintf("prelu_%d", nBlocks)];
+            catConnections = ["sm_1", "fc_3"];
+        case "o"
+            inputSize = 48;
+            nBlocks = 5;
+            finalConnections = ["fc_1", sprintf("prelu_%d", nBlocks)];
+            catConnections = ["sm_1", "fc_3", "fc_4"];
+        otherwise
+            error("mtcnn:convertToDagNet:unknownStage", ...
+            "Stage '%s' is not recognised", stage)
+    end
+
+    matFilename = strcat(stage, "net.mat");
+    weightsFile = load(fullfile(mtcnnRoot, "weights", matFilename));
+    input = dlarray(zeros(inputSize, inputSize, 3, "single"), "SSCB");
+    
+    switch stage
+        case "p"
+            netFunc = @(x) mtcnn.pnet(x, weightsFile);
+            [a, b] = netFunc(input);
+            output = cat(3, a, b);
+        case "r"
+            netFunc = @(x) mtcnn.rnet(x, weightsFile);
+            [a, b] = netFunc(input);
+            output = cat(1, a, b);
+        case "o"
+            netFunc = @(x) mtcnn.onet(x, weightsFile);
+            [a, b, c] = netFunc(input);
+            output = cat(1, a, b, c);
+    end
+    
+    lgraph = functionToLayerGraph(netFunc, input);
+    placeholders = findPlaceholderLayers(lgraph);
+    lgraph = removeLayers(lgraph, {placeholders.Name});
+
+    for iPrelu = 1:nBlocks
+        name = sprintf("prelu_%d", iPrelu);
+        weightName = sprintf("features_prelu%d_weight", iPrelu);
+        if iPrelu ~= nBlocks
+            weights = weightsFile.(weightName);
+        else
+            weights = reshape(weightsFile.(weightName), 1, 1, []);
+        end
+        prelu = mtcnn.util.preluLayer(weights, name);
+        lgraph = replaceLayer(lgraph, sprintf("plus_%d", iPrelu), prelu, "ReconnectBy", "order");
+
+        if iPrelu ~= nBlocks
+            lgraph = connectLayers(lgraph, sprintf("conv_%d", iPrelu), sprintf("prelu_%d", iPrelu));
+        else
+            % need to make different connections at the end of the
+            % repeating blocks
+            for iConnection = 1:size(finalConnections, 1)
+                lgraph = connectLayers(lgraph, ...
+                    finalConnections(iConnection, 1), ...
+                    finalConnections(iConnection, 2));
+            end
+
+        end
+    end
+
+    lgraph = addLayers(lgraph, imageInputLayer([inputSize, inputSize, 3], ...
+                                "Name", "input", ...
+                                "Normalization", "none"));
+    lgraph = connectLayers(lgraph, "input", "conv_1");
+
+    lgraph = addLayers(lgraph, concatenationLayer(3, numel(catConnections), "Name", "concat"));
+    for iConnection = 1:numel(catConnections)
+        lgraph = connectLayers(lgraph, ...
+                                catConnections(iConnection), ...
+                                sprintf("concat/in%d", iConnection));
+    end
+    lgraph = addLayers(lgraph, regressionLayer("Name", "output"));
+    lgraph = connectLayers(lgraph, "concat", "output");
+
+    net = assembleNetwork(lgraph);
+    result = net.predict(zeros(inputSize, inputSize, 3, "single"));
+
+    difference = extractdata(sum(output - result', "all"));
+    
+    assert(difference < 1e-6, ...
+        "mtcnn:convertToDagNet:outputMismatch", ...
+        "Outputs of function and dag net do not match")
+end

--- a/code/mtcnn/+mtcnn/+util/preluLayer.m
+++ b/code/mtcnn/+mtcnn/+util/preluLayer.m
@@ -25,5 +25,15 @@ classdef preluLayer < nnet.layer.Layer
             % layer and outputs the result Z.
             Z = max(X,0) + layer.Alpha .* min(0,X);
         end
+        
+        function [dLdX, dLdAlpha] = backward(layer, X, ~, dLdZ, ~)
+            dLdX = layer.Alpha .* dLdZ;
+            dLdX(X>0) = dLdZ(X>0);
+            dLdAlpha = min(0,X) .* dLdZ;
+            dLdAlpha = sum(sum(dLdAlpha,1),2);
+            
+            % Sum over all observations in mini-batch.
+            dLdAlpha = sum(dLdAlpha,4);
+        end
     end
 end

--- a/code/mtcnn/+mtcnn/+util/preluLayer.m
+++ b/code/mtcnn/+mtcnn/+util/preluLayer.m
@@ -1,0 +1,29 @@
+classdef preluLayer < nnet.layer.Layer
+    % Example custom PReLU layer.
+    % Taken from "Define Custom Deep Learning Layer with Learnable
+    % Parameters"
+    
+    %  Copyright 2020 The MathWorks, Inc.
+
+    properties (Learnable)
+        % Scaling coefficient
+        Alpha
+    end
+    
+    methods
+        function layer = preluLayer(weights, name) 
+            % layer = preluLayer(numChannels, name) creates a PReLU layer
+            % for 2-D image input with numChannels channels and specifies 
+            % the layer name.
+
+            layer.Name = name;
+            layer.Alpha = weights;
+        end
+        
+        function Z = predict(layer, X)
+            % Z = predict(layer, X) forwards the input data X through the
+            % layer and outputs the result Z.
+            Z = max(X,0) + layer.Alpha .* min(0,X);
+        end
+    end
+end

--- a/code/mtcnn/+mtcnn/Detector.m
+++ b/code/mtcnn/+mtcnn/Detector.m
@@ -25,6 +25,9 @@ classdef Detector < matlab.mixin.SetGet
         UseGPU = false
         % Use DAG Network for pre 19b compatibility
         UseDagNet = verLessThan('matlab', '9.7')
+    end
+    
+    properties (Access=private)
         % An object providing an inteface to the networks
         Networks
     end

--- a/code/mtcnn/+mtcnn/Detector.m
+++ b/code/mtcnn/+mtcnn/Detector.m
@@ -24,7 +24,7 @@ classdef Detector < matlab.mixin.SetGet
         % Use GPU for processing or not
         UseGPU = false
         % Use DAG Network for pre 19b compatibility
-        UseDagNet = false
+        UseDagNet = verLessThan('matlab', '9.7')
         % An object providing an inteface to the networks
         Networks
     end
@@ -129,6 +129,14 @@ classdef Detector < matlab.mixin.SetGet
             bboxes= gather(double(bboxes));
             scores = gather(double(scores));
             landmarks = gather(double(landmarks));
+        end
+        
+        function set.UseDagNet(obj, val)
+            if verLessThan('matlab', '9.7') && val
+                warning("mtcnn:Detector:pre19b", ...
+                    "For use in R2019a UseDagNet must be set to true");
+            end
+            obj.UseDagNet = val;
         end
     end
     

--- a/code/mtcnn/+mtcnn/Detector.m
+++ b/code/mtcnn/+mtcnn/Detector.m
@@ -23,6 +23,10 @@ classdef Detector < matlab.mixin.SetGet
         NmsThresholds = [0.5, 0.5, 0.5]
         % Use GPU for processing or not
         UseGPU = false
+        % Use DAG Network for pre 19b compatibility
+        UseDagNet = false
+        % An object providing an inteface to the networks
+        Networks
     end
     
     properties (Constant)
@@ -32,28 +36,23 @@ classdef Detector < matlab.mixin.SetGet
         OnetSize = 48
     end
     
-    properties (SetAccess=private)
-        % Weights for the networks
-        PnetWeights
-        RnetWeights
-        OnetWeights
-    end
     
     methods
         function obj = Detector(varargin)
             % Create an mtcnn.Detector object
             
-            obj.loadWeights();
-            
             if nargin > 1
                 obj.set(varargin{:});
             end
             
-            if obj.UseGPU()
-                obj.PnetWeights = dlupdate(@gpuArray, obj.PnetWeights);
-                obj.RnetWeights = dlupdate(@gpuArray, obj.RnetWeights);
-                obj.OnetWeights = dlupdate(@gpuArray, obj.OnetWeights);
+            if obj.UseDagNet
+                obj.Networks = mtcnn.util.DagNetworkStrategy();
+            else
+                obj.Networks = mtcnn.util.DlNetworkStrategy(obj.UseGPU);
             end
+            
+            obj.Networks.load();
+            
         end
         
         function [bboxes, scores, landmarks] = detect(obj, im)
@@ -87,7 +86,7 @@ classdef Detector < matlab.mixin.SetGet
                 [thisBox, thisScore] = ...
                     mtcnn.proposeRegions(im, scale, ...
                                             obj.ConfidenceThresholds(1), ...
-                                            obj.PnetWeights);
+                                            obj.Networks.getPNet());
                 bboxes = cat(1, bboxes, thisBox);
                 scores = cat(1, scores, thisScore);
             end
@@ -102,7 +101,7 @@ classdef Detector < matlab.mixin.SetGet
             
             %% Stage 2 - Refinement
             [cropped, bboxes] = obj.prepBbox(im, bboxes, obj.RnetSize);
-            [probs, correction] = mtcnn.rnet(cropped, obj.RnetWeights);
+            [probs, correction] = obj.Networks.applyRNet(cropped);
             [scores, bboxes] = obj.processOutputs(probs, correction, bboxes, 2);
             
             if isempty(scores)
@@ -116,14 +115,13 @@ classdef Detector < matlab.mixin.SetGet
             bboxes(:, 1:2) = bboxes(:, 1:2) - 0.5;
             bboxes(:, 3:4) = bboxes(:, 3:4) + 1;
             
-            [probs, correction, landmarks] = mtcnn.onet(cropped, obj.OnetWeights);
+            [probs, correction, landmarks] = obj.Networks.applyONet(cropped);
             
             % landmarks are relative to uncorrected bbox
-            landmarks = extractdata(landmarks)';
             x = bboxes(:, 1) + landmarks(:, 1:5).*(bboxes(:, 3));
             y = bboxes(:, 2) + landmarks(:, 6:10).*(bboxes(:, 4));
             landmarks = cat(3, x, y);
-            landmarks(extractdata(probs(2, :))' < obj.ConfidenceThresholds(3), :, :) = [];
+            landmarks(probs(:, 2) < obj.ConfidenceThresholds(3), :, :) = [];
             
             [scores, bboxes] = obj.processOutputs(probs, correction, bboxes, 3);
             
@@ -135,27 +133,17 @@ classdef Detector < matlab.mixin.SetGet
     end
     
     methods (Access=private)
-        function loadWeights(obj)
-            % loadWeights   Load the network weights from file.
-            obj.PnetWeights = load(fullfile(mtcnnRoot(), "weights", "pnet.mat"));
-            obj.RnetWeights = load(fullfile(mtcnnRoot(), "weights", "rnet.mat"));
-            obj.OnetWeights = load(fullfile(mtcnnRoot(), "weights", "onet.mat"));
-        end
-        
         function [cropped, bboxes] = prepBbox(obj, im, bboxes, outputSize)
             % prepImages    Pre-process the images and bounding boxes.
             bboxes = mtcnn.util.makeSquare(bboxes);
             bboxes = round(bboxes);
             cropped = mtcnn.util.cropImage(im, bboxes, outputSize);
-            cropped = dlarray(cropped, "SSCB");
-            
         end
         
         function [scores, bboxes] = ...
                 processOutputs(obj, probs, correction, bboxes, netIdx)
             % processOutputs    Post-process the output values.
-            faceProbs = extractdata(probs(2, :))';
-            correction = extractdata(correction)';
+            faceProbs = probs(:, 2);
             bboxes = mtcnn.util.applyCorrection(bboxes, correction);
             bboxes(faceProbs < obj.ConfidenceThresholds(netIdx), :) = [];
             scores = faceProbs(faceProbs > obj.ConfidenceThresholds(netIdx));

--- a/code/mtcnn/+mtcnn/detectFaces.m
+++ b/code/mtcnn/+mtcnn/detectFaces.m
@@ -24,6 +24,9 @@ function [bboxes, scores, landmarks] = detectFaces(im, varargin)
 %                                     (default=[0.5, 0.5, 0.5])
 %            - UseGPU               - Use GPU for processing or not
 %                                     (default=false)
+%            - UseDagNet            - Use DAGNetwork for prediction (for
+%                                     compatibility with R2019a)
+%                                     (default=false R2019b+, =true R2019a)
 % 
 %   Note:
 %       The 5 landmarks detector are in the order:

--- a/code/mtcnn/+mtcnn/proposeRegions.m
+++ b/code/mtcnn/+mtcnn/proposeRegions.m
@@ -14,7 +14,12 @@ function [bboxes, scores] = proposeRegions(im, scale, threshold, weightsOrNet)
 % Copyright 2019 The MathWorks, Inc.
 
     useDagNet = isa(weightsOrNet, "DAGNetwork");
-    assert(isa(im, "single"), "mtcnn:proposeRegions:wrongImageType", ...
+    if isa(im, "gpuArray")
+        imClass = classUnderlying(im);
+    else
+        imClass = class(im);
+    end
+    assert(imClass == "single", "mtcnn:proposeRegions:wrongImageType", ...
         "Input image should be a single scale -1 to 1");
 
     % Stride of the proposal network

--- a/code/mtcnn/+mtcnn/proposeRegions.m
+++ b/code/mtcnn/+mtcnn/proposeRegions.m
@@ -1,11 +1,11 @@
-function [bboxes, scores] = proposeRegions(im, scale, threshold, weights)
+function [bboxes, scores] = proposeRegions(im, scale, threshold, weightsOrNet)
 % proposeRegions    Generate region proposals at a given scale.
 %
 % Args:
 %   im          - Input image -1 to 1 range, type single
 %   scale       - Scale to run proposal at
 %   threshold   - Confidence threshold to accept proposal
-%   weights     - P-Net weights struct
+%   weights     - P-Net weights struct or trained network
 %
 % Returns:
 %   bboxes      - Nx4 array of bounding boxes
@@ -13,18 +13,29 @@ function [bboxes, scores] = proposeRegions(im, scale, threshold, weights)
 
 % Copyright 2019 The MathWorks, Inc.
 
+    useDagNet = isa(weightsOrNet, "DAGNetwork");
+    assert(isa(im, "single"), "mtcnn:proposeRegions:wrongImageType", ...
+        "Input image should be a single scale -1 to 1");
+
     % Stride of the proposal network
     stride = 2;
     % Field of view of the proposal network in pixels
     pnetSize = 12;
     
     im = imresize(im, 1/scale);
-    im = dlarray(im, "SSCB");
     
-    [probability, correction] = mtcnn.pnet(im, weights);
+    if useDagNet
+        % need to use activations as we don't know what size it will be
+        result = weightsOrNet.activations(im, "concat");
+        probability = gather(result(:,:,1:2,:));
+        correction = gather(result(:,:,3:end,:));
+    else
+        im = dlarray(im, "SSCB");
+        [probability, correction] = mtcnn.pnet(im, weightsOrNet);
+        probability = extractdata(gather(probability));
+        correction = extractdata(gather(correction));
+    end
     
-    probability = extractdata(gather(probability));
-    correction = extractdata(gather(correction));
     
     faces = probability(:,:,2) > threshold;
     if sum(faces, 'all') == 0

--- a/code/mtcnn/Contents.m
+++ b/code/mtcnn/Contents.m
@@ -1,5 +1,5 @@
 % MTCNN
-% Version 1.0.1 (R2019b) 22-January-2020
+% Version 1.2.0 (R2019b) 01-April-2020
 %
 % Files
 %   mtcnn.detectFaces   - Use a pretrained model to detect faces in an image.

--- a/install.m
+++ b/install.m
@@ -5,6 +5,18 @@ function install()
     folder = fileparts(mfilename('fullpath'));
     pathsToAdd = projectPaths();
     for iPath = 1:numel(pathsToAdd)
-        addpath(fullfile(folder, pathsToAdd(iPath)));
+        addpath(fullfile(folder, char(pathsToAdd(iPath))));
+    end
+    
+    % generate DAG net versions if not there already
+    nets = ["p", "r", "o"];
+    for iNet = 1:numel(nets)
+        thisNet = nets(iNet);
+        dagFile = fullfile(mtcnnRoot, 'weights', ...
+            strcat('dag', char(upper(thisNet)), 'Net.mat'));
+        if ~isfile(dagFile)
+            net = mtcnn.util.convertToDagNet(thisNet);
+            save(dagFile, "net");
+        end
     end
 end

--- a/mtcnn.prj
+++ b/mtcnn.prj
@@ -1,5 +1,5 @@
 <deployment-project plugin="plugin.toolbox" plugin-version="1.0">
-  <configuration build-checksum="4177056607" file="C:\code\internal\mtcnn-face-detection\mtcnn.prj" location="C:\code\internal\mtcnn-face-detection" name="mtcnn" target="target.toolbox" target-name="Package Toolbox">
+  <configuration build-checksum="1307712866" file="C:\code\internal\mtcnn-face-detection\mtcnn.prj" location="C:\code\internal\mtcnn-face-detection" name="mtcnn" target="target.toolbox" target-name="Package Toolbox">
     <param.appname>MTCNN Face Detection</param.appname>
     <param.authnamewatermark>Justin Pinkney</param.authnamewatermark>
     <param.email>jpinkney@mathworks.com</param.email>
@@ -8,7 +8,7 @@
     <param.description>This repository implements deep learning based face detection and facial landmark localisation using Multi-Task Cascaded CNNs.
 For more details see the GitHub repository: https://github.com/matlab-deep-learning/mtcnn-face-detection</param.description>
     <param.screenshot>${PROJECT_ROOT}\doc\logo.png</param.screenshot>
-    <param.version>1.0.1</param.version>
+    <param.version>1.2.0</param.version>
     <param.output>${PROJECT_ROOT}\MTCNN Face Detection.mltbx</param.output>
     <param.products.name>
       <item>Computer Vision Toolbox</item>
@@ -41,7 +41,7 @@ For more details see the GitHub repository: https://github.com/matlab-deep-learn
     <param.required.addons />
     <param.matlab.project.id />
     <param.matlab.project.name />
-    <param.release.start>R2019b</param.release.start>
+    <param.release.start>R2019a</param.release.start>
     <param.release.end>latest</param.release.end>
     <param.release.current.only>false</param.release.current.only>
     <param.compatiblity.windows>true</param.compatiblity.windows>

--- a/test/+tests/DetectorTest.m
+++ b/test/+tests/DetectorTest.m
@@ -12,6 +12,7 @@ classdef DetectorTest < matlab.unittest.TestCase
         imageTypeConversion = struct("uint8", @(x) x, ...
             "single", @(x) single(x)/255, ...
             "double", @(x) double(x)/255)
+        useDagNet = {false, true}
     end
     
     methods (TestClassSetup)
@@ -32,10 +33,10 @@ classdef DetectorTest < matlab.unittest.TestCase
             detector = mtcnn.Detector();
         end
         
-        function testDetectwithDefaults(test, imageTypeConversion)
+        function testDetectwithDefaults(test, imageTypeConversion, useDagNet)
             % Test expected inputs with images of type uint8, single,
             % double (float images are scaled 0-1);
-            detector = mtcnn.Detector();
+            detector = mtcnn.Detector("UseDagNet", useDagNet);
             
             inputImage = imageTypeConversion(test.Image);
             

--- a/test/+tests/ProposeRegionsTest.m
+++ b/test/+tests/ProposeRegionsTest.m
@@ -4,28 +4,34 @@ classdef ProposeRegionsTest < matlab.unittest.TestCase
     %  Copyright 2020 The MathWorks, Inc.
     
     properties (Constant)
-        Image = imread("visionteam.jpg");
-        Weights = load(fullfile(mtcnnRoot, "weights", "pnet.mat"));
+        Image = single(imread("visionteam.jpg"))/255*2 - 1
+    end
+    
+    properties (TestParameter)
+        getNet = struct("weights", @() load(fullfile(mtcnnRoot, "weights", "pnet.mat")), ...
+            "net", @() importdata(fullfile(mtcnnRoot, "weights", "dagPNet.mat")));
     end
     
     methods (Test)
-        function testOutputs(test)
+        function testOutputs(test, getNet)
             scale = 2;
             conf = 0.5;
+            weights = getNet();
             
-            [box, score] = mtcnn.proposeRegions(test.Image, scale, conf, test.Weights);
+            [box, score] = mtcnn.proposeRegions(test.Image, scale, conf, weights);
             
             test.verifyOutputs(box, score);
         end
         
-        function test1DActivations(test)
+        function test1DActivations(test, getNet)
             % Test for bug #6 (1xn activations causes proposeRegions to
             % fail)
             cropped = imcrop(test.Image, [300, 42, 65, 38]);
             scale = 3;
             conf = 0.5;
+            weights = getNet();
             
-            [box, score] = mtcnn.proposeRegions(cropped, scale, conf, test.Weights);
+            [box, score] = mtcnn.proposeRegions(cropped, scale, conf, weights);
             
             test.verifyOutputs(box, score);
         end


### PR DESCRIPTION
Adds support for MATLAB R2019a by converting dlarray functions to DAG networks.

Releases earlier the R2019a are not supported due to a lack of required layers.