### PR TITLE
Account for new gpuArray support in selectStrongestBboxes

### DIFF
--- a/code/mtcnn/+mtcnn/Detector.m
+++ b/code/mtcnn/+mtcnn/Detector.m
@@ -161,11 +161,9 @@ classdef Detector < matlab.mixin.SetGet
             if ~isempty(scores)
                 if verLessThan("matlab", "9.9")
                     % < R2020b no gpuArray support for selectStrongestBbox
-                    [inputs{:}] = gather(bboxes, scores);
-                else
-                    inputs = {bboxes, scores};
+                    [bboxes, scores] = gather(bboxes, scores);
                 end
-                [bboxes, scores, index] = selectStrongestBbox(inputs{:}, ...
+                [bboxes, scores, index] = selectStrongestBbox(bboxes, scores, ...
                                 "RatioType", "Min", ...
                                 "OverlapThreshold", obj.NmsThresholds(netIdx));
                 if netIdx == 3

--- a/code/mtcnn/+mtcnn/Detector.m
+++ b/code/mtcnn/+mtcnn/Detector.m
@@ -158,8 +158,14 @@ classdef Detector < matlab.mixin.SetGet
             bboxes = mtcnn.util.applyCorrection(bboxes, correction);
             bboxes(faceProbs < obj.ConfidenceThresholds(netIdx), :) = [];
             scores = faceProbs(faceProbs >= obj.ConfidenceThresholds(netIdx));
-            if ~isempty(scores) 
-                [bboxes, scores, index] = selectStrongestBbox(gather(bboxes), scores, ...
+            if ~isempty(scores)
+                if verLessThan("matlab", "9.9")
+                    % < R2020b no gpuArray support for selectStrongestBbox
+                    [inputs{:}] = gather(bboxes, scores);
+                else
+                    inputs = {bboxes, scores};
+                end
+                [bboxes, scores, index] = selectStrongestBbox(inputs{:}, ...
                                 "RatioType", "Min", ...
                                 "OverlapThreshold", obj.NmsThresholds(netIdx));
                 if netIdx == 3


### PR DESCRIPTION
Fixes #20.

selectStrongestBbox got gpuArray support in MATLAB R2020b. Previously the gather was required if bboxes was gpuArray and needed to be on the cpu (strangely the scores didn't matter).

In R2020b they need to be the same either both on the gpu or not, so we
do a version check and adjust behaviour accordingly